### PR TITLE
Refactor integration tests

### DIFF
--- a/lib/tenant-resolver.js
+++ b/lib/tenant-resolver.js
@@ -14,10 +14,7 @@ module.exports = function tenantResolver(req, res, next) {
     var tenantType = tenantParams[i].type;
     if (!param || typeof param !== tenantType) {
       var errMsg = f('Invalid %s. Expected %s, got %s.',
-        tenantName,
-        tenantType,
-        typeof param
-      );
+        tenantName, tenantType, typeof param);
       err = new Error(errMsg);
       break;
     }

--- a/test/integration/tenant-resolver.js
+++ b/test/integration/tenant-resolver.js
@@ -9,13 +9,22 @@ describe('tenant resolver', function() {
   before(setUpLoopBackApp);
   before(registerTenantResolver);
 
-  it('should set tenant data on the request object', function(done) {
+  it('sets tenant data on the request object', function(done) {
+    var observedRequest = null;
     app.use(function(req, res, next) {
-      expect(req.tenant).to.eql({id: '1', modelId: '2', modelName: 'Todo'});
+      observedRequest = req;
+      next();
+    });
+    request(app).get('/api/1/2/Todo').end(function(err) {
+      if (err) return done(err);
+
+      expect(observedRequest).to.have.property('tenant').eql({
+        id: '1',
+        modelId: '2',
+        modelName: 'Todo',
+      });
       done();
     });
-    app.use(loopback.rest()); // must be called later in the middleware chain
-    request(app).get('/api/1/2/Todo').end();
   });
 });
 
@@ -24,7 +33,6 @@ function setUpLoopBackApp() {
   var db = app.dataSource('db', {connector: 'memory'});
   var Todo = app.registry.createModel('Todo', {});
   Todo.attachTo(db);
-  app.set('legacyExplorer', false);
 }
 
 function registerTenantResolver() {


### PR DESCRIPTION
- Remove legacyExplorer false setting
- Remove loopback.rest() middleware registration
- Observe req object and test in the request's callback instead
